### PR TITLE
feat: set event value to elapsed duration if playback is live

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ If this option is enabled, the eventValue is set to :
 * player position value in seconds for `play`, `pause`, `stop` and `ended` events
 * player "seek to" position value in seconds for `seek` event _(may be an unexpected value for LIVE playback with DVR)_
 * player volume percent value for `volume` event
+* 0 or 1 for `highdefinitionupdate` and `playbackdvrstatechanged` events
 
 If playback type is __LIVE__, the eventValue is set to elapsed duration since __play__ event in seconds. _(It use a Timer instead of referring to player position)_
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ If this option is enabled, the eventValue is set to :
 * player "seek to" position value in seconds for `seek` event
 * player volume percent value for `volume` event
 
+If playback type is __LIVE__, the eventValue is set to elapsed since __play__ event in seconds. _(It use a Timer instead of referring to player position)_
+
 ```javascript
   /* [...] */
   gaEventsPlugin: {
@@ -94,7 +96,7 @@ If this option is enabled, the eventValue is set to :
   /* [...] */
 ```
 
-__Note:__ The event value is truncated using [parseInt()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) function to convert to integer. If container playback type is LIVE, the player position value always equals zero.
+__Note:__ The event value is truncated using [parseInt()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) function to convert to integer.
 
 ## eventToTrack
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ If this option is set to `true`, the "play" event is send only once after video 
   /* [...] */
 ```
 
+## stopOnLeave
+
+`stopOnLeave` __optional__ property is a boolean which indicate if player is paused or stopped when user decides to leave the page. Default value is `false`.
+
+If this option is set to `true`, "beacon" [transport](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport) will be used (if available) to __attempt__ to send the event.
+
+__Note:__ this option may not be supported by all browsers, and therefore is not guaranteed to work.
+
 ## sendExceptions
 
 `sendExceptions` __optional__ property is a boolean which indicate if container `error` events are send to Google Analytics using [Exception](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#exception) ("exception" hit type). Default value is `false`. _(default behaviour, if "error" is tracked, is to use "send" hit type like other player events)_

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If this option is enabled, the eventValue is set to :
 * player position value in seconds for `play`, `pause`, `stop` and `ended` events
 * player "seek to" position value in seconds for `seek` event _(may be an unexpected value for LIVE playback with DVR)_
 * player volume percent value for `volume` event
-* 0 or 1 for `highdefinitionupdate` and `playbackdvrstatechanged` events
+* 0 or 1 for `fullscreen`, `highdefinitionupdate`, and `playbackdvrstatechanged` events
 
 If playback type is __LIVE__, the eventValue is set to elapsed duration since __play__ event in seconds. _(It use a Timer instead of referring to player position)_
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ __Note:__ This option is ignored if playback type is __LIVE__. _(eventValueAuto 
 
 __Note:__ the list of available events is `['ready', 'buffering', 'bufferfull', 'loadedmetadata', 'play', 'seek', 'pause', 'stop', 'ended', 'volume', 'fullscreen', 'error', 'playbackstate', 'highdefinitionupdate', 'playbackdvrstatechanged']`. _This is not the complete Clappr container event list. If you think one or more event is needed, just open an issue or a pull request._
 
-Keep in mind that "Web Property / Property / Tracking ID" limit is 10 million hits per month per property. For more details, read [Google Analytics Collection Limits and Quotas](https://developers.google.com/analytics/devguides/collection/analyticsjs/limits-quotas).
+Keep in mind that Analytics limit is 200,000 hits per __user__ per day and 500 hits per __session__. For more details, read [Google Analytics Collection Limits and Quotas](https://developers.google.com/analytics/devguides/collection/analyticsjs/limits-quotas).
 
 ```javascript
   /* [...] */

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ it's __strongly recommended__ to set this option. Using video source as event la
 If this option is enabled, the eventValue is set to :
 
 * player position value in seconds for `play`, `pause`, `stop` and `ended` events
-* player "seek to" position value in seconds for `seek` event
+* player "seek to" position value in seconds for `seek` event _(may be an unexpected value for LIVE playback with DVR)_
 * player volume percent value for `volume` event
 
-If playback type is __LIVE__, the eventValue is set to elapsed since __play__ event in seconds. _(It use a Timer instead of referring to player position)_
+If playback type is __LIVE__, the eventValue is set to elapsed duration since __play__ event in seconds. _(It use a Timer instead of referring to player position)_
 
 ```javascript
   /* [...] */
@@ -97,6 +97,30 @@ If playback type is __LIVE__, the eventValue is set to elapsed since __play__ ev
 ```
 
 __Note:__ The event value is truncated using [parseInt()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) function to convert to integer.
+
+## eventValueAsLive
+
+`eventValueAsLive` __optional__ property is a boolean which indicate if "on demand" playback is handled as __LIVE__ playback. Default value is `false`.
+
+If this option and `eventValueAuto` are enabled, the eventValue is always set to elapsed duration since __play__ event in seconds.
+
+For consistency, `play` event value is set to 0 _(same as LIVE playback)_ but `ended` event value is still set to position. _(ie: duration)_
+
+This option may be usefull, for example, to track the playing time of "on demand" playback. _(stop & pause event values)_
+
+This option does __NOT__ affect `progressSeconds`, `progressPercent` and `progressEachSeconds` behaviours.
+
+```javascript
+  /* [...] */
+  gaEventsPlugin: {
+    trackingId: 'UA-XXXX-Y',
+    eventValueAuto: true,
+    eventValueAsLive: true,
+  }
+  /* [...] */
+```
+
+__Note:__ This option is ignored if playback type is __LIVE__. _(eventValueAuto option default behaviour)_
 
 ## eventToTrack
 

--- a/public/index.html
+++ b/public/index.html
@@ -47,6 +47,7 @@
           // eventCategory: 'MyCategory',
           eventLabel: 'Trailer',
           // eventValueAuto: true,
+          // eventValueAsLive: true,
           // eventToTrack: ['play', 'seek', 'pause', 'stop', 'ended', 'volume', 'buffering', 'bufferfull', 'fullscreen'],
           // eventMapping: {
           //   pause: function(p) { return 'pause_at_'+p+'_seconds'; },
@@ -57,7 +58,7 @@
           // sendExceptionsMsg: true,
           // progressSeconds: [10, 20, 30, 40, 50, 60],
           // progressPercent: [25, 50, 75, 100],
-          // progressEachSeconds: 10,
+          // progressEachSeconds: 9,
         },
       });
 

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
           eventLabel: 'Trailer',
           // eventValueAuto: true,
           // eventValueAsLive: true,
+          // stopOnLeave: true,
           // eventToTrack: ['play', 'seek', 'pause', 'stop', 'ended', 'volume', 'buffering', 'bufferfull', 'fullscreen'],
           // eventMapping: {
           //   pause: function(p) { return 'pause_at_'+p+'_seconds'; },

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export default class GaEventsPlugin extends CorePlugin {
       this._hasEvent('bufferfull') && this.listenTo(this.__container, Events.CONTAINER_STATE_BUFFERFULL, this.onBufferFull)
       this._hasEvent('loadedmetadata') && this.listenTo(this.__container, Events.CONTAINER_LOADEDMETADATA, this.onLoadedMetadata)
       this._hasEvent('volume') && this.listenTo(this.__container, Events.CONTAINER_VOLUME, (event) => this.onVolumeChanged(event))
-      this._hasEvent('fullscreen') && this.listenTo(this.__container, Events.CONTAINER_FULLSCREEN, this.onFullscreen)
+      this._hasEvent('fullscreen') && this.listenTo(this.core, Events.CORE_FULLSCREEN, this.onCoreFullscreen)
       this._hasEvent('playbackstate') && this.listenTo(this.__container, Events.CONTAINER_PLAYBACKSTATE, this.onPlaybackChanged)
       this._hasEvent('highdefinitionupdate') && this.listenTo(this.__container, Events.CONTAINER_HIGHDEFINITIONUPDATE, this.onHD)
       this._hasEvent('playbackdvrstatechanged') && this.listenTo(this.__container, Events.CONTAINER_PLAYBACKDVRSTATECHANGED, this.onDVR)
@@ -352,9 +352,9 @@ export default class GaEventsPlugin extends CorePlugin {
     }, 400)
   }
 
-  onFullscreen() {
-    // TODO: create Clappr PR to add missing boolean argument to CONTAINER_FULLSCREEN event
-    this.gaEvent(this._category, this._action('fullscreen'), this._label)
+  onCoreFullscreen(isFullscreen) {
+    let v = isFullscreen ? 1 : 0
+    this.gaEvent(this._category, this._action('fullscreen'), this._label, this._value(v))
   }
 
   onPlaybackChanged(playbackState) {

--- a/src/index.js
+++ b/src/index.js
@@ -362,11 +362,13 @@ export default class GaEventsPlugin extends CorePlugin {
   }
 
   onHD(isHD) {
-    this.gaEvent(this._category, this._action('highdefinitionupdate'), this._label)
+    let v = isHD ? 1 : 0
+    this.gaEvent(this._category, this._action('highdefinitionupdate'), this._label, this._value(v))
   }
 
   onDVR(dvrInUse) {
-    this.gaEvent(this._category, this._action('playbackdvrstatechanged'), this._label)
+    let v = dvrInUse ? 1 : 0
+    this.gaEvent(this._category, this._action('playbackdvrstatechanged'), this._label, this._value(v))
   }
 
   resolveErrMsg(o) {

--- a/src/index.js
+++ b/src/index.js
@@ -344,11 +344,11 @@ export default class GaEventsPlugin extends CorePlugin {
     this._processGaPercent && this.processGaPercent(this.duration)
   }
 
-  onVolumeChanged(e) {
+  onVolumeChanged(percent) {
     // Rate limit to avoid HTTP hammering
     clearTimeout(this._volumeTimer)
     this._volumeTimer = setTimeout(() => {
-      this.gaEvent(this._category, this._action('volume', this.trunc(e)), this._label, this._value(this.trunc(e)))
+      this.gaEvent(this._category, this._action('volume', this.trunc(percent)), this._label, this._value(this.trunc(percent)))
     }, 400)
   }
 


### PR DESCRIPTION
* Use progress timer to automatically set event value _(if enabled)_ to elapsed duration in seconds
* Fix an issue with playback type detection _(live mp3 radio is "live" while playing but "aod" when stopped)_
* add missing values for "fullscreen", "highdefinitionupdate", and "playbackdvrstatechanged" events
* add new `eventValueAsLive` option to handle "on demand" playback as LIVE
* add new `stopOnLeave` option
